### PR TITLE
Fixed CENTER_CROP not center image if border_width > 0.

### DIFF
--- a/library/src/com/makeramen/rounded/RoundedDrawable.java
+++ b/library/src/com/makeramen/rounded/RoundedDrawable.java
@@ -116,7 +116,7 @@ public class RoundedDrawable extends Drawable {
             }
 
             mShaderMatrix.setScale(scale, scale);
-            mShaderMatrix.postTranslate((int) (dx + 0.5f), (int) (dy + 0.5f));
+            mShaderMatrix.postTranslate((int) (dx + 0.5f) + mBorderWidth, (int) (dy + 0.5f) + mBorderWidth);
 			break;
 		case CENTER_INSIDE:
 			Log.d(TAG, "CENTER_INSIDE");


### PR DESCRIPTION
CENTER_CROP should translate image's x,y along with border_width to display it correctly.
