### PR TITLE
Git ignores IDE related files for Eclipse and Idea

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,13 @@ libs/library/gen/
 local.properties
 
 *.DS_Store
+
+# IDE
+
+## eclipse
+*.metadata
+*.settings
+
+## idea
+*.idea
+*.iml


### PR DESCRIPTION
Git should better ignore IDE-related files to use library as a submodule.
