### PR TITLE
RoundedDrawable will not be redrawn after setAlpha() on some devices.

### DIFF
--- a/library/src/com/makeramen/rounded/RoundedDrawable.java
+++ b/library/src/com/makeramen/rounded/RoundedDrawable.java
@@ -216,11 +216,13 @@ public class RoundedDrawable extends Drawable {
 	@Override
 	public void setAlpha(int alpha) {
 		mBitmapPaint.setAlpha(alpha);
+		invalidateSelf();
 	}
 
 	@Override
 	public void setColorFilter(ColorFilter cf) {
 		mBitmapPaint.setColorFilter(cf);
+		invalidateSelf();
 	}
 
 	@Override


### PR DESCRIPTION
I found that on some devices RoundedDrawable will not be redrawn after setAlpha() is called.
It causes a problem when animating a view with alpha transition(fade in/out), the rounded drawable remains transparent with last value, just before draw() called, of setAlpha() and never be redrawn itself even though animation set its alpha back with 255.

Tested on below devices.

RoundedDrawable remains transparent.
Samsung Galaxy S3(SHV-E201L, Android 4.0.4)
Samsung Galaxy Note(SHV-E160L, Android 4.0.4)

RoundedDrawable redraws correctly.
Samsung Galaxy Nexus(Galaxy Nexus, Android 4.2.2)
