### PR TITLE
Persist the mOval param in RoundedImageDrawable to draw oval shapes

### DIFF
--- a/roundedimageview/src/com/makeramen/RoundedDrawable.java
+++ b/roundedimageview/src/com/makeramen/RoundedDrawable.java
@@ -63,6 +63,8 @@ public class RoundedDrawable extends Drawable {
         mBorderPaint.setAntiAlias(true);
         mBorderPaint.setColor(mBorderColor.getColorForState(getState(), DEFAULT_BORDER_COLOR));
         mBorderPaint.setStrokeWidth(border);
+    
+        mOval = oval;
     }
 
     @Override


### PR DESCRIPTION
Use the mOval parameter - not sure if there was a reason this was omitted originally, but I've been using it, and it seems to work fine.

Looks like it might have been intentionally omitted, however, so I'd love to hear if there's an issue with this.
