### PR TITLE
fixed artifact packaging containing "aar.asc" ext

### DIFF
--- a/roundedimageview/build.gradle
+++ b/roundedimageview/build.gradle
@@ -38,19 +38,12 @@ artifacts {
     archives androidJavadocsJar
 }
 
-configurations {
-    archives {
-        extendsFrom configurations.default
-    }
-}
-
 signing {
     required { has("release") && gradle.taskGraph.hasTask("uploadArchives") }
     sign configurations.archives
 }
 
 uploadArchives {
-    configuration = configurations.archives
     repositories.mavenDeployer {
         beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 


### PR DESCRIPTION
I ran into this exactly issue in my https://github.com/dkharrat/nexus-dialog Android library and came across your issue #19 when I was trying to find solutions online. I've finally fixed the issue: you just need to remove the `configurations.archives` settings in the build.gradle. I thought I'd contribute a pull request to help fix this issue for your library too.
