### PR TITLE
Add support for animated drawables

### DIFF
--- a/roundedimageview/src/com/makeramen/RoundedDrawable.java
+++ b/roundedimageview/src/com/makeramen/RoundedDrawable.java
@@ -4,7 +4,6 @@ import android.content.res.ColorStateList;
 import android.graphics.*;
 import android.graphics.Bitmap.Config;
 import android.graphics.drawable.*;
-import android.util.Log;
 import android.widget.ImageView.ScaleType;
 
 public class RoundedDrawable extends Drawable {


### PR DESCRIPTION
This is a pull-request adding one additional commit on top of #24. This PR is however not ready for merging, as there is a bug where the last frame of the animation is not always drawn (which can be seen occasionally if testing with [ion](https://github.com/koush/ion) with its default fade-in behavior enabled). I suspect this is because we don't sync on the paint clock by using `android.view.Choreographer.postFrameCallback()` (available in API level 19), but further debugging is definitely needed. This PR is here in the hope it will help you or others find the right solution to support animated drawables in case I won't have time to finish it in the near future.
