### PR TITLE
Reset the state of matrix object using a proper reset method.

### DIFF
--- a/roundedimageview/src/main/java/com/makeramen/RoundedDrawable.java
+++ b/roundedimageview/src/main/java/com/makeramen/RoundedDrawable.java
@@ -146,7 +146,7 @@ public class RoundedDrawable extends Drawable {
         mBorderRect.set(mBounds);
         mBorderRect.inset((mBorderWidth) / 2, (mBorderWidth) / 2);
 
-        mShaderMatrix.set(null);
+        mShaderMatrix.reset();
         mShaderMatrix.setTranslate((int) ((mBorderRect.width() - mBitmapWidth) * 0.5f + 0.5f),
             (int) ((mBorderRect.height() - mBitmapHeight) * 0.5f + 0.5f));
         break;
@@ -155,7 +155,7 @@ public class RoundedDrawable extends Drawable {
         mBorderRect.set(mBounds);
         mBorderRect.inset((mBorderWidth) / 2, (mBorderWidth) / 2);
 
-        mShaderMatrix.set(null);
+        mShaderMatrix.reset();
 
         dx = 0;
         dy = 0;
@@ -174,7 +174,7 @@ public class RoundedDrawable extends Drawable {
         break;
 
       case CENTER_INSIDE:
-        mShaderMatrix.set(null);
+        mShaderMatrix.reset();
 
         if (mBitmapWidth <= mBounds.width() && mBitmapHeight <= mBounds.height()) {
           scale = 1.0f;
@@ -223,7 +223,7 @@ public class RoundedDrawable extends Drawable {
       case FIT_XY:
         mBorderRect.set(mBounds);
         mBorderRect.inset((mBorderWidth) / 2, (mBorderWidth) / 2);
-        mShaderMatrix.set(null);
+        mShaderMatrix.reset();
         mShaderMatrix.setRectToRect(mBitmapRect, mBorderRect, Matrix.ScaleToFit.FILL);
         break;
     }


### PR DESCRIPTION
This library is pretty awesome, I'm really happy with that! :)

Currently I'm having an issue when trying to run Robolectric tests that inflates layouts containing a RoundedImageView:

```
Caused by: java.lang.NullPointerException: can't get a shadow for null
    at org.robolectric.bytecode.ShadowWrangler.shadowOf(ShadowWrangler.java:432)
    at org.robolectric.Robolectric.shadowOf_(Robolectric.java:1034)
    at org.robolectric.Robolectric.shadowOf(Robolectric.java:741)
    at org.robolectric.shadows.ShadowMatrix.set(ShadowMatrix.java:64)
    at android.graphics.Matrix.set(Matrix.java)
```

Since android.graphics.Matrix.set(param) does a null check, and calls android.graphics.Matrix.reset() when the param is null - [see android.graphics.Matrix code, line 260](http://grepcode.com/file/repository.grepcode.com/java/ext/com.google.android/android/4.4.4_r1/android/graphics/Matrix.java?av=f), it might not be a problem to directly call the reset instead of set(null). This would keep everything working as before, and would make Robolectric happy! =]
