### PR TITLE
Fixed issue with rendering colors on Lollipop

### DIFF
--- a/roundedimageview/src/main/java/com/makeramen/RoundedDrawable.java
+++ b/roundedimageview/src/main/java/com/makeramen/RoundedDrawable.java
@@ -105,8 +105,8 @@ public class RoundedDrawable extends Drawable {
     }
 
     Bitmap bitmap;
-    int width = Math.max(drawable.getIntrinsicWidth(), 1);
-    int height = Math.max(drawable.getIntrinsicHeight(), 1);
+    int width = Math.max(drawable.getIntrinsicWidth(), 2);
+    int height = Math.max(drawable.getIntrinsicHeight(), 2);
     try {
       bitmap = Bitmap.createBitmap(width, height, Config.ARGB_8888);
       Canvas canvas = new Canvas(bitmap);


### PR DESCRIPTION
For some reason, a BitmapShader with a backing Bitmap of size 1x1 renders
incorrectly on Lollipop. The easy solution is to make 2x2 the minimum size
when converting a Drawable to a Bitmap.

Should fix https://github.com/vinc3m1/RoundedImageView/issues/60
