### PR TITLE
BitmapDrawable with a null Bitmap is valid/legal

### DIFF
--- a/roundedimageview/src/main/java/com/makeramen/roundedimageview/RoundedDrawable.java
+++ b/roundedimageview/src/main/java/com/makeramen/roundedimageview/RoundedDrawable.java
@@ -110,8 +110,6 @@ public class RoundedDrawable extends Drawable {
       Bitmap bm = drawableToBitmap(drawable);
       if (bm != null) {
         return new RoundedDrawable(bm);
-      } else {
-        Log.w(TAG, "Failed to create bitmap from drawable!");
       }
     }
     return drawable;
@@ -132,6 +130,7 @@ public class RoundedDrawable extends Drawable {
       drawable.draw(canvas);
     } catch (Exception e) {
       e.printStackTrace();
+      Log.w(TAG, "Failed to create bitmap from drawable!");
       bitmap = null;
     }
 


### PR DESCRIPTION
Do not show a warning in the log when this happens.

Move the warning to when Bitmap generation fails.