### PR TITLE
Provide source bitmap from RoundedDrawable

### DIFF
--- a/roundedimageview/src/main/java/com/makeramen/roundedimageview/RoundedDrawable.java
+++ b/roundedimageview/src/main/java/com/makeramen/roundedimageview/RoundedDrawable.java
@@ -137,6 +137,10 @@ public class RoundedDrawable extends Drawable {
     return bitmap;
   }
 
+  public Bitmap getSourceBitmap() {
+    return mBitmap;
+  }
+
   @Override
   public boolean isStateful() {
     return mBorderColor.isStateful();


### PR DESCRIPTION
Underlying original bitmap is needed to achieve integration with 3-rd party libraries, e.g. when you try to implement cache hit of ImageView's bitmap and Picasso, like at `Palette` [integration example](https://gist.github.com/almozavr/501d5b3643f0be233525)

