### PR TITLE
rebuild shader on ShaderMatrix update

### DIFF
--- a/roundedimageview/src/main/java/com/makeramen/roundedimageview/RoundedDrawable.java
+++ b/roundedimageview/src/main/java/com/makeramen/roundedimageview/RoundedDrawable.java
@@ -257,6 +257,7 @@ public class RoundedDrawable extends Drawable {
     }
 
     mDrawableRect.set(mBorderRect);
+    mRebuildShader = true;
   }
 
   @Override


### PR DESCRIPTION
When ShaderMatrix is changed, the shader should be rebuilt. If not, then drawable will not be scaled properly. You may catch such case when imageView is scaled after device orientation is changed.