### PR TITLE
docs: use implementation instead of compile on README.md

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-   Copyright (c) 2019, Vincent Mi
+   Copyright (c) 2017, Vincent Mi
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-   Copyright (c) 2017, Vincent Mi
+   Copyright (c) 2019, Vincent Mi
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.makeramen:roundedimageview:2.3.0'
+    implementation 'com.makeramen:roundedimageview:2.3.0'
 }
 ```
 
@@ -112,7 +112,7 @@ see [Releases](https://github.com/vinc3m1/RoundedImageView/releases)
 
 ## License
 
-    Copyright 2017 Vincent Mi
+    Copyright 2019 Vincent Mi
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ see [Releases](https://github.com/vinc3m1/RoundedImageView/releases)
 
 ## License
 
-    Copyright 2019 Vincent Mi
+    Copyright 2017 Vincent Mi
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
In the most recent versions of gradle `compile` has been deprecated in favor of `implementation`.