### PR TITLE
Fix issue when background is RippleDrawable / LayerDrawable

### DIFF
--- a/roundedimageview/src/main/java/com/makeramen/roundedimageview/RoundedDrawable.java
+++ b/roundedimageview/src/main/java/com/makeramen/roundedimageview/RoundedDrawable.java
@@ -103,7 +103,9 @@ public class RoundedDrawable extends Drawable {
         // just return if it's already a RoundedDrawable
         return drawable;
       } else if (drawable instanceof LayerDrawable) {
-        LayerDrawable ld = (LayerDrawable) drawable;
+        ConstantState cs = drawable.mutate().getConstantState();
+        LayerDrawable ld = (LayerDrawable) (cs != null ? cs.newDrawable() : drawable);
+
         int num = ld.getNumberOfLayers();
 
         // loop through layers to and change to RoundedDrawables if possible


### PR DESCRIPTION
To reproduce change [this line](https://github.com/vinc3m1/RoundedImageView/blob/master/example/src/main/res/layout/rounded_background_item.xml#L21) to `?attr/selectableItemBackground` and navigate to "Background" in the example app.  You'll see the following:

```
14860-14860/com.makeramen.roundedimageview.example W/LayerDrawable: Invalid drawable added to LayerDrawable! Drawable already belongs to another owner but does not expose a constant state.
    java.lang.RuntimeException
        at android.graphics.drawable.LayerDrawable$ChildDrawable.<init>(LayerDrawable.java:1848)
        at android.graphics.drawable.LayerDrawable$LayerState.<init>(LayerDrawable.java:1967)
        at android.graphics.drawable.RippleDrawable$RippleState.<init>(RippleDrawable.java:979)
        at android.graphics.drawable.RippleDrawable.<init>(RippleDrawable.java:1032)
        at android.graphics.drawable.RippleDrawable.<init>(RippleDrawable.java:96)
        at android.graphics.drawable.RippleDrawable$RippleState.newDrawable(RippleDrawable.java:1021)
        at android.graphics.drawable.Drawable$ConstantState.newDrawable(Drawable.java:1470)
        at android.content.res.DrawableCache.getInstance(DrawableCache.java:37)
        at android.content.res.ResourcesImpl.loadDrawable(ResourcesImpl.java:598)
        at android.content.res.Resources.loadDrawable(Resources.java:897)
        at android.content.res.TypedArray.getDrawableForDensity(TypedArray.java:955)
        at android.content.res.TypedArray.getDrawable(TypedArray.java:930)
        at android.view.View.<init>(View.java:5010)
        at android.widget.ImageView.<init>(ImageView.java:177)
        at android.widget.ImageView.<init>(ImageView.java:172)
        at com.makeramen.roundedimageview.RoundedImageView.<init>(RoundedImageView.java:89)
        at com.makeramen.roundedimageview.RoundedImageView.<init>(RoundedImageView.java:85)
    ...
```

In addition to noisy logs, the resulting UI issue can be misshapen ripples in other views.  The fix is to make a copy of the background drawable, which can be shared between other views, while mutating.